### PR TITLE
BZ-2923: chore: Bump Electron SDK to v233.0.0

### DIFF
--- a/src/iframe.ts
+++ b/src/iframe.ts
@@ -36,11 +36,11 @@ function initiate(
     switch (payloadData.environment) {
       case 'smbBeta':
       case 'smbRelease':
-        scriptSrc = 'https://sdk.breezesdk.store/electron/232.0.0/index.js';
+        scriptSrc = 'https://sdk.breezesdk.store/electron/233.0.0/index.js';
         environment = payloadData.environment === 'smbBeta' ? 'beta' : 'release';
         break;
       default:
-        scriptSrc = 'https://sdk.breeze.in/electron/232.0.0/index.js';
+        scriptSrc = 'https://sdk.breeze.in/electron/233.0.0/index.js';
         environment = payloadData.environment === 'beta' ? 'beta' : 'release';
         break;
     }


### PR DESCRIPTION
Update electron SDK script source to v233.0.0 for both smb (beta/release) and default (beta/release) environments, upgrading from 217.0.0 and 196.0.0 respectively.