### PR TITLE
BZ-2891: chore: bump electron version to 240.0.1

### DIFF
--- a/src/iframe.ts
+++ b/src/iframe.ts
@@ -36,11 +36,11 @@ function initiate(
     switch (payloadData.environment) {
       case 'smbBeta':
       case 'smbRelease':
-        scriptSrc = 'https://sdk.breezesdk.store/electron/233.0.0/index.js';
+        scriptSrc = 'https://sdk.breezesdk.store/electron/240.0.1/index.js';
         environment = payloadData.environment === 'smbBeta' ? 'beta' : 'release';
         break;
       default:
-        scriptSrc = 'https://sdk.breeze.in/electron/233.0.0/index.js';
+        scriptSrc = 'https://sdk.breeze.in/electron/240.0.1/index.js';
         environment = payloadData.environment === 'beta' ? 'beta' : 'release';
         break;
     }


### PR DESCRIPTION
Bump atoms CDN version to 240.0.1 which includes the checkout navigation interceptor fix for bank redirect URLs in portal context.