### PR TITLE
BZ-5209: feat: send sessionId in headers of payment Initiate

### DIFF
--- a/package.json
+++ b/package.json
@@ -159,6 +159,7 @@
   },
   "dependencies": {
     "type-decoder": "^2.1.0",
-    "typesafe-api-call": "^5.1.1"
+    "typesafe-api-call": "^5.1.1",
+    "nanoid": "^5.0.4"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,9 @@ settings:
 importers:
   .:
     dependencies:
+      nanoid:
+        specifier: ^5.0.4
+        version: 5.1.16
       type-decoder:
         specifier: ^2.1.0
         version: 2.3.0
@@ -1028,7 +1031,6 @@ packages:
       {
         integrity: sha512-v5hkh1us7sMNjfimWE70flYbD5I1/qWQaqmJ45q2qk5H/7muQVa478LSVRSFyGTBUBog2LsPQnfIRdjyWJRY+A==
       }
-    cpu: [arm64, x64]
     os: [darwin, linux, win32]
     hasBin: true
 
@@ -2141,6 +2143,14 @@ packages:
       {
         integrity: sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==
       }
+
+  nanoid@5.1.16:
+    resolution:
+      {
+        integrity: sha512-kVrnsrJqMR8+oLJnGEmSWw9BivK5mt7H3FZatVRjrc5wGqFYuBxX1yG7+A7Gi5AefkX6t/oCkizcQgpu0cY1dQ==
+      }
+    engines: { node: ^18 || >=20 }
+    hasBin: true
 
   natural-compare@1.4.0:
     resolution:
@@ -4000,6 +4010,8 @@ snapshots:
   ms@2.1.3: {}
 
   mute-stream@0.0.8: {}
+
+  nanoid@5.1.16: {}
 
   natural-compare@1.4.0: {}
 

--- a/src/backend/handlers.ts
+++ b/src/backend/handlers.ts
@@ -12,7 +12,7 @@ import {
   decodeActionEnum
 } from '$generated/Backend';
 import { environmentUrls, paymentEndpoint } from './constants';
-import { toSdkResponse, incorrectPayloadResp } from './utils';
+import { toSdkResponse, incorrectPayloadResp, _nanoid } from './utils';
 import type { CallbackFn } from '$types';
 import type { NetworkOverrides } from './types';
 
@@ -68,7 +68,8 @@ async function processInitiatePayments(
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        Authorization: token
+        Authorization: token,
+        'X-Session-Id': _nanoid()
       },
       body: JSON.stringify({
         cart: paymentsData.cart,

--- a/src/backend/utils.ts
+++ b/src/backend/utils.ts
@@ -1,5 +1,6 @@
 import type { SDKResponse, EventName } from '$generated/types';
 import type { ActionEnum } from '$generated/Backend';
+import { nanoid } from 'nanoid';
 
 export function incorrectPayloadResp(
   requestId: string | null,
@@ -28,4 +29,14 @@ export function toSdkResponse(
       ...data
     }
   };
+}
+
+export function _nanoid(): string {
+  const nanoId = nanoid();
+  const firstChar = nanoId.charAt(0);
+  if (firstChar === '_' || firstChar === '-') {
+    const randomCharacter = String.fromCharCode(97 + Math.floor(Math.random() * 26));
+    return randomCharacter + nanoId.substring(1);
+  }
+  return nanoId;
 }


### PR DESCRIPTION
## Summary
Sends a unique session identifier in the headers of the payment **Initiate** request, to help correlate/trace individual payment initiation calls.

## Changes
- **`src/backend/utils.ts`**: Added a new `_nanoid()` helper wrapping the `nanoid` package to generate a random ID, with a safeguard that replaces the first character with a random lowercase letter if it happens to be non-alphanumeric (avoids IDs starting with special characters).
- **`src/backend/handlers.ts`**: `processInitiatePayments` now sends an `X-Session-Id` header (generated via `_nanoid()`) alongside the existing `Authorization` header on the payment initiate POST request.
- **`package.json` / `pnpm-lock.yaml`**: Added `nanoid` (`^5.0.4`) as a new dependency.

## Plane Ticket
https://plane.breezehq.dev/breeze/browse/BZ-5209/

## Dev Proof 
https://drive.google.com/file/d/16oc7YVDtbD6urIa2PdmYyjmHUlI9JdKQ/view?usp=drive_link

## Testing
- Verified the payment initiate request now includes a valid `X-Session-Id` header.
- Confirmed generated IDs never start with a special character.